### PR TITLE
Show fingerprint for duplicate nicknames

### DIFF
--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -1331,18 +1331,24 @@ class ChatViewModel: ObservableObject {
                 }
                 
                 // Add the match with appropriate styling
-                let matchText = String(contentText[range])
+                var matchText = String(contentText[range])
                 var matchStyle = AttributeContainer()
                 matchStyle.font = .system(size: 14, weight: .semibold, design: .monospaced)
-                
+
                 if matchType == "mention" {
                     matchStyle.foregroundColor = Color.orange
+
+                    // Replace with display name if we know the peer
+                    let nick = String(matchText.dropFirst())
+                    if let peerID = getPeerIDForNickname(nick) {
+                        matchText = "@" + displayName(for: peerID)
+                    }
                 } else {
                     // Hashtag
                     matchStyle.foregroundColor = Color.blue
                     matchStyle.underlineStyle = .single
                 }
-                
+
                 processedContent.append(AttributedString(matchText).mergingAttributes(matchStyle))
                 
                 lastEndIndex = range.upperBound
@@ -1441,17 +1447,22 @@ class ChatViewModel: ObservableObject {
                     }
                     
                     // Add styled match
-                    let matchText = String(content[nsRange])
+                    var matchText = String(content[nsRange])
                     var matchStyle = AttributeContainer()
                     matchStyle.font = .system(size: 14, weight: .semibold, design: .monospaced)
-                    
+
                     if type == "hashtag" {
                         matchStyle.foregroundColor = Color.blue
                         matchStyle.underlineStyle = .single
                     } else if type == "mention" {
                         matchStyle.foregroundColor = Color.orange
+
+                        let nick = String(matchText.dropFirst())
+                        if let peerID = getPeerIDForNickname(nick) {
+                            matchText = "@" + displayName(for: peerID)
+                        }
                     }
-                    
+
                     result.append(AttributedString(matchText).mergingAttributes(matchStyle))
                     lastEnd = nsRange.upperBound
                 }

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -30,8 +30,6 @@ class ChatViewModel: ObservableObject {
     @Published var privateChats: [String: [BitchatMessage]] = [:] // peerID -> messages
     @Published var selectedPrivateChatPeer: String? = nil
     @Published var unreadPrivateMessages: Set<String> = []
-    // Autocomplete suggestions for @mentions. Stores peer IDs so we can
-    // disambiguate duplicate nicknames when presenting options.
     @Published var autocompleteSuggestions: [String] = []
     @Published var showAutocomplete: Bool = false
     @Published var autocompleteRange: NSRange? = nil

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -1090,12 +1090,14 @@ class ChatViewModel: ObservableObject {
                                    nickname: String?,
                                    allNicknames: [String: String],
                                    myNickname: String,
-                                   fingerprint: String?) -> String {
+                                   fingerprint: String?,
+                                   isSelf: Bool = false) -> String {
         let baseName = nickname ?? "person-\(peerID.prefix(4))"
+
         var count = allNicknames.values.filter { $0 == baseName }.count
         if myNickname == baseName { count += 1 }
 
-        if count > 1, nickname != nil {
+        if !isSelf && count > 1, nickname != nil {
             let short = String((fingerprint ?? peerID).prefix(4))
             return "\(baseName)-\(short)"
         }
@@ -1118,7 +1120,8 @@ class ChatViewModel: ObservableObject {
                                                nickname: nick,
                                                allNicknames: all,
                                                myNickname: nickname,
-                                               fingerprint: fingerprint)
+                                               fingerprint: fingerprint,
+                                               isSelf: peerID == meshService.myPeerID)
     }
     
     // PANIC: Emergency data clearing for activist safety

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -913,18 +913,18 @@ struct ContentView: View {
                         let sortedPeers = peersToShow.sorted { peer1, peer2 in
                             let isFav1 = viewModel.isFavorite(peerID: peer1)
                             let isFav2 = viewModel.isFavorite(peerID: peer2)
-                            
+
                             if isFav1 != isFav2 {
                                 return isFav1 // Favorites come first
                             }
-                            
-                            let name1 = peerNicknames[peer1] ?? "person-\(peer1.prefix(4))"
-                            let name2 = peerNicknames[peer2] ?? "person-\(peer2.prefix(4))"
+
+                            let name1 = viewModel.displayName(for: peer1)
+                            let name2 = viewModel.displayName(for: peer2)
                             return name1 < name2
                         }
                         
                         ForEach(sortedPeers, id: \.self) { peerID in
-                            let displayName = peerID == myPeerID ? viewModel.nickname : (peerNicknames[peerID] ?? "person-\(peerID.prefix(4))")
+                            let displayName = viewModel.displayName(for: peerID)
                             let rssi = peerRSSI[peerID]?.intValue ?? -100
                             let isFavorite = viewModel.isFavorite(peerID: peerID)
                             let isMe = peerID == myPeerID

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -169,7 +169,7 @@ struct ContentView: View {
     private var headerView: some View {
         HStack {
             if let privatePeerID = viewModel.selectedPrivateChatPeer,
-               let privatePeerNick = viewModel.meshService.getPeerNicknames()[privatePeerID] {
+               let _ = viewModel.meshService.getPeerNicknames()[privatePeerID] {
                 // Private chat header
                 Button(action: {
                     viewModel.endPrivateChat()
@@ -190,7 +190,7 @@ struct ContentView: View {
                     Image(systemName: "lock.fill")
                         .font(.system(size: 14))
                         .foregroundColor(Color.orange)
-                    Text("private: \(privatePeerNick)")
+                    Text("private: \(viewModel.displayName(for: privatePeerID))")
                         .font(.system(size: 16, weight: .medium, design: .monospaced))
                         .foregroundColor(Color.orange)
                 }
@@ -487,12 +487,12 @@ struct ContentView: View {
             // @mentions autocomplete
             if viewModel.showAutocomplete && !viewModel.autocompleteSuggestions.isEmpty {
                 VStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(viewModel.autocompleteSuggestions.enumerated()), id: \.element) { index, suggestion in
+                    ForEach(Array(viewModel.autocompleteSuggestions.enumerated()), id: \.element) { index, peerID in
                         Button(action: {
-                            _ = viewModel.completeNickname(suggestion, in: &messageText)
+                            _ = viewModel.completeNickname(peerID, in: &messageText)
                         }) {
                             HStack {
-                                Text("@\(suggestion)")
+                                Text("@\(viewModel.displayName(for: peerID))")
                                     .font(.system(size: 11, design: .monospaced))
                                     .foregroundColor(textColor)
                                     .fontWeight(.medium)
@@ -589,21 +589,21 @@ struct ContentView: View {
             
             HStack(alignment: .center, spacing: 4) {
             if viewModel.selectedPrivateChatPeer != nil {
-                Text("<@\(viewModel.nickname)> →")
+                Text("<@\(viewModel.displayName(for: viewModel.meshService.myPeerID))> →")
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
                     .foregroundColor(Color.orange)
                     .lineLimit(1)
                     .fixedSize()
                     .padding(.leading, 12)
             } else if let currentChannel = viewModel.currentChannel, viewModel.passwordProtectedChannels.contains(currentChannel) {
-                Text("<@\(viewModel.nickname)> →")
+                Text("<@\(viewModel.displayName(for: viewModel.meshService.myPeerID))> →")
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
                     .foregroundColor(Color.orange)
                     .lineLimit(1)
                     .fixedSize()
                     .padding(.leading, 12)
             } else {
-                Text("<@\(viewModel.nickname)>")
+                Text("<@\(viewModel.displayName(for: viewModel.meshService.myPeerID))>")
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
                     .foregroundColor(textColor)
                     .lineLimit(1)

--- a/bitchatTests/DisplayNameTests.swift
+++ b/bitchatTests/DisplayNameTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import bitchat
+
+class DisplayNameTests: XCTestCase {
+    func testDuplicateNicknamesAppendFingerprint() {
+        let nicknames = ["peerA": "alice", "peerB": "alice", "peerC": "bob"]
+        let nameA = ChatViewModel.computeDisplayName(peerID: "peerA",
+                                                    nickname: "alice",
+                                                    allNicknames: nicknames,
+                                                    myNickname: "carol",
+                                                    fingerprint: "abcd1234")
+        let nameB = ChatViewModel.computeDisplayName(peerID: "peerB",
+                                                    nickname: "alice",
+                                                    allNicknames: nicknames,
+                                                    myNickname: "carol",
+                                                    fingerprint: "efgh5678")
+        XCTAssertEqual(nameA, "alice-abcd")
+        XCTAssertEqual(nameB, "alice-efgh")
+    }
+
+    func testUniqueNicknameNoFingerprint() {
+        let nicknames = ["peerA": "alice", "peerB": "bob"]
+        let name = ChatViewModel.computeDisplayName(peerID: "peerB",
+                                                   nickname: "bob",
+                                                   allNicknames: nicknames,
+                                                   myNickname: "carol",
+                                                   fingerprint: "1234")
+        XCTAssertEqual(name, "bob")
+    }
+
+    func testDuplicateWithSelf() {
+        let nicknames = ["peerA": "carol"]
+        let name = ChatViewModel.computeDisplayName(peerID: "peerA",
+                                                   nickname: "carol",
+                                                   allNicknames: nicknames,
+                                                   myNickname: "carol",
+                                                   fingerprint: "abcd")
+        XCTAssertEqual(name, "carol-abcd")
+    }
+}

--- a/bitchatTests/DisplayNameTests.swift
+++ b/bitchatTests/DisplayNameTests.swift
@@ -38,6 +38,17 @@ class DisplayNameTests: XCTestCase {
         XCTAssertEqual(name, "carol-abcd")
     }
 
+    func testSelfDisplayNameNoFingerprint() {
+        let nicknames = ["peerA": "carol"]
+        let name = ChatViewModel.computeDisplayName(peerID: "peerA",
+                                                   nickname: "carol",
+                                                   allNicknames: nicknames,
+                                                   myNickname: "carol",
+                                                   fingerprint: "abcd",
+                                                   isSelf: true)
+        XCTAssertEqual(name, "carol")
+    }
+
     func testMentionReplacesWithDisplayName() {
         let nicknames = ["peerA": "alice", "peerB": "alice"]
         let fingerprints = ["peerA": "abcd1234", "peerB": "efgh5678"]

--- a/bitchatTests/DisplayNameTests.swift
+++ b/bitchatTests/DisplayNameTests.swift
@@ -37,4 +37,17 @@ class DisplayNameTests: XCTestCase {
                                                    fingerprint: "abcd")
         XCTAssertEqual(name, "carol-abcd")
     }
+
+    func testMentionReplacesWithDisplayName() {
+        let nicknames = ["peerA": "alice", "peerB": "alice"]
+        let fingerprints = ["peerA": "abcd1234", "peerB": "efgh5678"]
+
+        let display = ChatViewModel.computeDisplayName(peerID: "peerA",
+                                                      nickname: nicknames["peerA"],
+                                                      allNicknames: nicknames,
+                                                      myNickname: "carol",
+                                                      fingerprint: fingerprints["peerA"])
+
+        XCTAssertEqual("@" + display, "@alice-abcd")
+    }
 }


### PR DESCRIPTION
## Summary
- append a peer's fingerprint to their nickname if duplicates exist
- use new `displayName(for:)` helper in ContentView and message formatting
- add tests covering display name behaviour when nicknames collide

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686c7bc5eec08325a8af24c2bebc029d