### PR TITLE
Refactor header view

### DIFF
--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -1215,6 +1215,15 @@ class ChatViewModel: ObservableObject {
         let nicknames = meshService.getPeerNicknames()
         return nicknames.first(where: { $0.value == nickname })?.key
     }
+
+    func displayName(for peerID: String) -> String {
+        if peerID == meshService.myPeerID {
+            return nickname
+        }
+
+        let peerNicknames = meshService.getPeerNicknames()
+        return peerNicknames[peerID] ?? "person-\(peerID.prefix(4))"
+    }
     
     // PANIC: Emergency data clearing for activist safety
     func panicClearAllData() {

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -168,8 +168,7 @@ struct ContentView: View {
     
     private var headerView: some View {
         HStack {
-            if let privatePeerID = viewModel.selectedPrivateChatPeer,
-               let privatePeerNick = viewModel.meshService.getPeerNicknames()[privatePeerID] {
+            if let privatePeerID = viewModel.selectedPrivateChatPeer {
                 // Private chat header
                 Button(action: {
                     viewModel.endPrivateChat()
@@ -190,7 +189,7 @@ struct ContentView: View {
                     Image(systemName: "lock.fill")
                         .font(.system(size: 14))
                         .foregroundColor(Color.orange)
-                    Text("\(privatePeerNick)")
+                    Text("\(viewModel.displayName(for: privatePeerID))")
                         .font(.system(size: 16, weight: .medium, design: .monospaced))
                         .foregroundColor(Color.orange)
                 }


### PR DESCRIPTION
## Summary
- use `displayName(for:)` helper in header
- add `displayName(for:)` helper to ChatViewModel

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686c9bb306d88325b9af368e594c2f41