### PR TITLE
Fix peer ID connection callbacks

### DIFF
--- a/bitchat/Services/BluetoothMeshService.swift
+++ b/bitchat/Services/BluetoothMeshService.swift
@@ -1859,7 +1859,7 @@ class BluetoothMeshService: NSObject {
                     if isFirstAnnounce {
                         announcedPeers.insert(senderID)
                         DispatchQueue.main.async {
-                            self.delegate?.didConnectToPeer(nickname)
+                            self.delegate?.didConnectToPeer(senderID)
                         }
                         self.notifyPeerListUpdate(immediate: true)
                         
@@ -1931,7 +1931,7 @@ class BluetoothMeshService: NSObject {
                         
                         // Show leave message
                         DispatchQueue.main.async {
-                            self.delegate?.didDisconnectFromPeer(nickname)
+                            self.delegate?.didDisconnectFromPeer(senderID)
                         }
                         self.notifyPeerListUpdate()
                         
@@ -2406,7 +2406,7 @@ extension BluetoothMeshService: CBCentralManagerDelegate {
             
             if let nickname = nickname, nickname != peerID {
                 DispatchQueue.main.async {
-                    self.delegate?.didDisconnectFromPeer(nickname)
+                    self.delegate?.didDisconnectFromPeer(peerID)
                 }
             }
             self.notifyPeerListUpdate()


### PR DESCRIPTION
## Summary
- ensure connection callbacks use the peer ID instead of nickname

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686c9ba84dbc8325acbcbc3b27b8c9f7